### PR TITLE
Fixes thumb dimensions exceeding sampleMaxSize

### DIFF
--- a/classes/ThumbHash.php
+++ b/classes/ThumbHash.php
@@ -37,8 +37,8 @@ class ThumbHash
     // Generate a sample image for encode to avoid memory issues.
     $max = $kirby->option('tobimori.thumbhash.sampleMaxSize'); // Max width or height
 
-    $height = round($file->height() > $file->width() ? $max : $max / $options['ratio']);
-    $width = round($file->width() > $file->height() ? $max : $max * $options['ratio']);
+    $height = round($options['ratio'] < 1 ? $max : $max / $options['ratio']);
+    $width = round($options['ratio'] >= 1 ? $max : $max * $options['ratio']);
     $options = [
       'width' => $width,
       'height' => $height,


### PR DESCRIPTION
Current version looks at the original file's ratio when setting the thumbnail's largest side, not the passed-in crop ratio. This leads to thumb file sizes exceeding the sampleMaxSize when cropping a portrait image to a landscape version.